### PR TITLE
Fix for missing token id error

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -52,7 +52,7 @@ export default NextAuth({
     // if you want to override the default behaviour.
     encode: async ({ secret, token, maxAge }) => {
       const jwtClaims = {
-        "sub": token.id.toString() ,
+        "sub": token.sub.toString() ,
         "name": token.name ,
         "email": token.email,
         "iat": Date.now() / 1000,


### PR DESCRIPTION
next-auth throws the following error: 

```sh
[next-auth][error][jwt_session_error]
https://next-auth.js.org/errors#jwt_session_error TypeError: Cannot read property 'toString' of undefined
```


Since the `encode` function in the `jwt` section is called twice, the first time [`token.id` is available, while the second time it is not](https://github.com/praveenweb/next-auth-hasura-example/blob/main/pages/api/auth/%5B...nextauth%5D.js#L55), which is when the error above is thrown.


```
// token argument with first call
{
  name: 'JP Wesselink',
  ...
  sub: '{userId}',
  id: '{userId}'
}

```

```
// token argument with second call
{
  sub: '{userId}',
  ...
  'https://hasura.io/jwt/claims': {
    'x-hasura-allowed-roles': [ 'user' ],
    'x-hasura-default-role': 'user',
    'x-hasura-role': 'user',
    'x-hasura-user-id': '{userId}'
  }
}
```

Since `sub` is set in both calls, we can safely use that in lieu of `id`.

